### PR TITLE
[FIX] Replace LAFAN1 file loading with BVH file loading

### DIFF
--- a/scripts/bvh_to_robot_dataset.py
+++ b/scripts/bvh_to_robot_dataset.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 import torch
 import pickle
 
-from general_motion_retargeting.utils.lafan1 import load_lafan1_file
+from general_motion_retargeting.utils.lafan1 import load_bvh_file
 from general_motion_retargeting.kinematics_model import KinematicsModel
 from general_motion_retargeting import GeneralMotionRetargeting as GMR
 from rich import print
@@ -73,7 +73,7 @@ if __name__ == "__main__":
             
             # Load LAFAN1 trajectory
             try:
-                lafan1_data_frames, actual_human_height = load_lafan1_file(bvh_file_path)
+                lafan1_data_frames, actual_human_height = load_bvh_file(bvh_file_path)
                 src_fps = 30  # LAFAN1 data is typically 30 FPS
             except Exception as e:
                 print(f"Error loading {bvh_file_path}: {e}")
@@ -82,7 +82,7 @@ if __name__ == "__main__":
             
             # Initialize the retargeting system
             retarget = GMR(
-                src_human="bvh",
+                src_human="bvh_lafan1",
                 tgt_robot=args.robot,
                 actual_human_height=actual_human_height,
             )
@@ -93,7 +93,8 @@ if __name__ == "__main__":
 
             # retarget to get all qpos
             qpos_list = []
-            for curr_frame in range(len(lafan1_data_frames)):
+            print(f"Processing {len(lafan1_data_frames)} frames for {filename}...")
+            for curr_frame in tqdm(range(len(lafan1_data_frames)), desc="Frames", leave=False):
                 smplx_data = lafan1_data_frames[curr_frame]
                 
                 # Retarget till convergence


### PR DESCRIPTION
- There is no **load_lafan1_file** function anymore
- Which will lead to two errors
- Hope it will help

```sh
ImportError: cannot import name 'load_lafan1_file' from 'general_motion_retargeting.utils.lafan1' (/home/lyd/GMR/general_motion_retargeting/utils/lafan1.py)
```

```sh
Traceback (most recent call last):
  File "/home/lyd/GMR/scripts/bvh_to_robot_dataset.py", line 84, in <module>
    retarget = GMR(
  File "/home/lyd/GMR/general_motion_retargeting/motion_retarget.py", line 57, in __init__
    with open(IK_CONFIG_DICT[src_human][tgt_robot]) as f:
KeyError: 'bvh'
```