### PR TITLE
Update scipy version requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     "mink",
     "mujoco",
     "numpy",
-    "scipy",
+    "scipy>=1.14",
     "qpsolvers[proxqp]",
     "rich",
     "tqdm",


### PR DESCRIPTION
Scipy needs to be higher or equal to 1.14 to use the argument of scalar_first when converting the rotation to a quaternion : https://github.com/YanjieZe/GMR/blob/1986066a686f8ad6384209af1e54d5e46ad63bbb/general_motion_retargeting/utils/smpl.py#L254


[scipy 1.14 release note](https://docs.scipy.org/doc/scipy-1.17.0/release/1.14.0-notes.html#scipy-spatial-improvements)