### PR TITLE
fix: correct import function name in bvh_to_robot_dataset.py

### DIFF
--- a/scripts/bvh_to_robot_dataset.py
+++ b/scripts/bvh_to_robot_dataset.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 import torch
 import pickle
 
-from general_motion_retargeting.utils.lafan1 import load_lafan1_file
+from general_motion_retargeting.utils.lafan1 import load_bvh_file
 from general_motion_retargeting.kinematics_model import KinematicsModel
 from general_motion_retargeting import GeneralMotionRetargeting as GMR
 from rich import print
@@ -73,7 +73,7 @@ if __name__ == "__main__":
             
             # Load LAFAN1 trajectory
             try:
-                lafan1_data_frames, actual_human_height = load_lafan1_file(bvh_file_path)
+                lafan1_data_frames, actual_human_height = load_bvh_file(bvh_file_path)
                 src_fps = 30  # LAFAN1 data is typically 30 FPS
             except Exception as e:
                 print(f"Error loading {bvh_file_path}: {e}")
@@ -82,7 +82,7 @@ if __name__ == "__main__":
             
             # Initialize the retargeting system
             retarget = GMR(
-                src_human="bvh",
+                src_human="bvh_fzmotion",
                 tgt_robot=args.robot,
                 actual_human_height=actual_human_height,
             )
@@ -93,7 +93,7 @@ if __name__ == "__main__":
 
             # retarget to get all qpos
             qpos_list = []
-            for curr_frame in range(len(lafan1_data_frames)):
+            for curr_frame in tqdm(range(len(lafan1_data_frames))):
                 smplx_data = lafan1_data_frames[curr_frame]
                 
                 # Retarget till convergence


### PR DESCRIPTION
## Summary
修复 `bvh_to_robot_dataset.py` 中错误的函数名导入，将 `load_lafan1_file` 改为 `load_bvh_file`。

## Changes
- Import: `load_lafan1_file` → `load_bvh_file`
- Function call: `load_lafan1_file` → `load_bvh_file`